### PR TITLE
Docs: Fixes broken link in express docs

### DIFF
--- a/docs/ecosystem/express.md
+++ b/docs/ecosystem/express.md
@@ -22,7 +22,7 @@ app.listen(port, () => {
 Bun implements the [`node:http`](https://nodejs.org/api/http.html) and [`node:https`](https://nodejs.org/api/https.html) modules that these libraries rely on. These modules can also be used directly, though [`Bun.serve`](/docs/api/http) is recommended for most use cases.
 
 {% callout %}
-**Note** — Refer to the [Runtime > Node.js APIs](/docs/runtime/nodejs#node_http) page for more detailed compatibility information.
+**Note** — Refer to the [Runtime > Node.js APIs](/docs/ecosystem/nodejs#node_http) page for more detailed compatibility information.
 {% /callout %}
 
 ```ts


### PR DESCRIPTION
Fixes broken internal link to nodejs compatability information.